### PR TITLE
Trimmed and final(?) version

### DIFF
--- a/context.jsonld
+++ b/context.jsonld
@@ -1,66 +1,35 @@
 {
     "@context": {
-        "type": "@type",
-        "id": "@id",
-        "none": "@none",
-        "language": "@language",
-        "direction": "@direction",
-        "json": "@json",
+        "dc11"     : "http://purl.org/dc/elements/1.1/",
+        "dcterms"  : "http://purl.org/dc/terms/",
+        "dctype"   : "http://purl.org/dc/dcmitype/",
+        "rdf"      : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs"     : "http://www.w3.org/2000/01/rdf-schema#",
+        "schema"   : "http://schema.org/",
+        "xsd"      : "http://www.w3.org/2001/XMLSchema#",
 
-        "as": "https://www.w3.org/ns/activitystreams#",
-        "bibo" : "http://purl.org/ontology/bibo/",
-        "cc": "http://creativecommons.org/ns#",
-        "csvw": "http://www.w3.org/ns/csvw#",
-        "dcat": "http://www.w3.org/ns/dcat#",
-        "dc": "http://purl.org/dc/elements/1.1/",
-        "dc11": "http://purl.org/dc/elements/1.1/",
-        "dct": "http://purl.org/dc/terms/",
-        "dcterms": "http://purl.org/dc/terms/",
-        "dctype": "http://purl.org/dc/dcmitype/",
-        "dqv": "http://www.w3.org/ns/dqv#",
-        "duv": "https://www.w3.org/TR/vocab-duv#",
-        "eli" : "http://data.europa.eu/eli/ontology#",
-        "foaf": "http://xmlns.com/foaf/0.1/",
-        "ldp": "http://www.w3.org/ns/ldp#",
-        "ma": "http://www.w3.org/ns/ma-ont#",
-        "oa": "http://www.w3.org/ns/oa#",
-        "odrl": "http://www.w3.org/ns/odrl/2/",
-        "og": "http://ogp.me/ns#",
-        "org": "http://www.w3.org/ns/org#",
-        "owl": "http://www.w3.org/2002/07/owl#",
-        "prov": "http://www.w3.org/ns/prov#",
-        "qb": "http://purl.org/linked-data/cube#",
-        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "rr": "http://www.w3.org/ns/r2rml#",
-        "schema": "http://schema.org/",
-        "sioc": "http://rdfs.org/sioc/ns#",
-        "skos": "http://www.w3.org/2004/02/skos/core#",
-        "skosxl": "http://www.w3.org/2008/05/skos-xl#",
-        "snomed": "http://purl.bioontology.org/ontology/SNOMEDCT/",
-        "ssn": "http://www.w3.org/ns/ssn/",
-        "sosa": "http://www.w3.org/ns/sosa/",
-        "time": "http://www.w3.org/2006/time#",
-        "vcard": "http://www.w3.org/2006/vcard/ns#",
-        "void": "http://rdfs.org/ns/void#",
-        "xhv": "http://www.w3.org/1999/xhtml/vocab#",
-        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "type"      : "@type",
+        "id"        : "@id",
+        "none"      : "@none",
+        "language"  : "@language",
+        "direction" : "@direction",
+        "json"      : "@json",
+        "HTML"      : "rdf:HTML",
+        "JSON"      : "rdf:JSON",
 
-        "license": {
-            "@id" : "xhv:license",
-            "@type": "@id"
+        "license"     : {
+            "@id"   : "http://www.w3.org/1999/xhtml/vocab#license",
+            "@type" : "@id"
         },
-        "label": "rdfs:label",
-        "comment": "rdfs:comment",
-        "isDefinedBy": {
-            "@id" : "rdfs:isDefinedBy",
+        "label"       : "rdfs:label",
+        "comment"     : "rdfs:comment",
+        "isDefinedBy" : {
+            "@id"   : "rdfs:isDefinedBy",
             "@type" : "@id"
         },
         "seeAlso": {
-            "@id" : "rdfs:seeAlso",
+            "@id"   : "rdfs:seeAlso",
             "@type" : "@id"
-        },
-        "HTML": "rdf:HTML",
-        "JSON": "rdf:JSON"
+        }
     }
 }

--- a/context.jsonld
+++ b/context.jsonld
@@ -8,25 +8,28 @@
         "schema"   : "http://schema.org/",
         "xsd"      : "http://www.w3.org/2001/XMLSchema#",
 
-        "type"      : "@type",
-        "id"        : "@id",
-        "none"      : "@none",
-        "language"  : "@language",
-        "direction" : "@direction",
-        "json"      : "@json",
         "HTML"      : "rdf:HTML",
         "JSON"      : "rdf:JSON",
 
-        "license"     : {
-            "@id"   : "http://www.w3.org/1999/xhtml/vocab#license",
-            "@type" : "@id"
-        },
-        "label"       : "rdfs:label",
+        "direction" : "@direction",
+        "graph"     : "@graph",
+        "id"        : "@id",
+        "included"  : "@included",
+        "json"      : "@json",
+        "language"  : "@language",
+        "none"      : "@none",
+        "type"      : "@type",
+
         "comment"     : "rdfs:comment",
         "isDefinedBy" : {
             "@id"   : "rdfs:isDefinedBy",
             "@type" : "@id"
         },
+        "license"     : {
+            "@id"   : "schema:license",
+            "@type" : "@id"
+        },
+        "label"       : "rdfs:label",
         "seeAlso": {
             "@id"   : "rdfs:seeAlso",
             "@type" : "@id"


### PR DESCRIPTION
I have made the changes as discussed on [2010-04-17](https://www.w3.org/2018/json-ld-wg/Meetings/Minutes/2020/2020-04-17-json-ld#section3).

Some things that we have not discussed, we may want to take care of this with this PR:

- I have kept the extra terms of the sort `license`, `comment`, `label`, `seeAlso`, etc. I think they are useful, mainly the `comment` that can then be used as, well, a comment in a JSON-LD file.
- I have looked at the spec for other aliases that we _may_ want to include as a matter of consistency. If we have `@none`, we may want to have `@list`, `@set`, `@nest`, etc. (Actually we may include almost all keywords). Which is, imho, an overkill. My approach would be to only alias terms that are typically used in the data and not terms mostly used within context files. What this may mean is to:
    - _add_ `@graph` and `@included`
    - _remove_ `@json`, `@none`




Fix #1  
Fix #5  
Fix #6  

