### PR TITLE
GitHub workflow 

### DIFF
--- a/.github/workflows/publication-workflow.yml
+++ b/.github/workflows/publication-workflow.yml
@@ -1,0 +1,28 @@
+# This workflow builds alternate versions of the RDFa initial context
+# and the derived JSON-LD context.
+name: RDFa Initial Context publication
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      with:
+        ruby-version: 2.7
+    - name: Install dependencies
+      run: bundle install
+    - name: Create derivative files
+      run: bundle exec rake
+    - name: Commit derived files
+      uses: stefanzweifel/git-auto-commit-action@v4.1.6
+      with:
+        commit_message: Update derived files
+        branch: ${{ github.head_ref }}
+        file_pattern: ./*.ttl ./*.rdf ./*.jsonld

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+gem 'rake'
+gem 'nokogiri'
+gem 'nokogumbo'
+gem 'rdf'
+gem 'rdf-turtle'
+gem 'rdf-rdfa'
+gem 'rdf-rdfxml'
+gem 'json-ld'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,71 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    concurrent-ruby (1.1.6)
+    ebnf (1.2.0)
+      rdf (~> 3.1)
+      sxp (~> 1.1)
+    haml (5.1.2)
+      temple (>= 0.8.0)
+      tilt
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    htmlentities (4.3.4)
+    json-canonicalization (0.2.0)
+    json-ld (3.1.1)
+      htmlentities (~> 4.3)
+      json-canonicalization (~> 0.2)
+      link_header (~> 0.0, >= 0.0.8)
+      multi_json (~> 1.14)
+      rack (~> 2.0)
+      rdf (~> 3.1)
+    link_header (0.0.8)
+    mini_portile2 (2.4.0)
+    multi_json (1.14.1)
+    nokogiri (1.10.9)
+      mini_portile2 (~> 2.4.0)
+    nokogumbo (2.0.2)
+      nokogiri (~> 1.8, >= 1.8.4)
+    rack (2.2.2)
+    rake (13.0.1)
+    rdf (3.1.1)
+      hamster (~> 3.0)
+      link_header (~> 0.0, >= 0.0.8)
+    rdf-aggregate-repo (3.1.0)
+      rdf (~> 3.1)
+    rdf-rdfa (3.1.0)
+      haml (~> 5.1)
+      htmlentities (~> 4.3)
+      rdf (~> 3.1)
+      rdf-aggregate-repo (~> 3.1)
+      rdf-xsd (~> 3.1)
+    rdf-rdfxml (3.1.0)
+      htmlentities (~> 4.3)
+      rdf (~> 3.1)
+      rdf-rdfa (~> 3.1)
+      rdf-xsd (~> 3.1)
+    rdf-turtle (3.1.0)
+      ebnf (~> 1.2)
+      rdf (~> 3.1)
+    rdf-xsd (3.1.0)
+      rdf (~> 3.1)
+    sxp (1.1.0)
+      rdf (~> 3.1)
+    temple (0.8.2)
+    tilt (2.0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json-ld
+  nokogiri
+  nokogumbo
+  rake
+  rdf
+  rdf-rdfa
+  rdf-rdfxml
+  rdf-turtle
+
+BUNDLED WITH
+   2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,26 @@
+# Build files based on rdfa-1.1.html
+
+task default: :publish
+
+desc "Build files resulting from rdfa-1.1.html"
+task publish: %w(rdfa-1.1.ttl rdfa-1.1.rdf rdfa-1.1.jsonld context.jsonld)
+
+desc "Build rdfa-1.1.ttl from rdfa-1.1.html"
+file "rdfa-1.1.ttl" => "rdfa-1.1.html" do
+  sh "rdf serialize --output-format ttl rdfa-1.1.html -o rdfa-1.1.ttl"
+end
+
+desc "Build rdfa-1.1.rdf from rdfa-1.1.html"
+file "rdfa-1.1.rdf" => "rdfa-1.1.html" do
+  sh "rdf serialize --output-format rdfxml rdfa-1.1.html -o rdfa-1.1.rdf"
+end
+
+desc "Build rdfa-1.1.jsonld from rdfa-1.1.html"
+file "rdfa-1.1.jsonld" => "rdfa-1.1.html" do
+  sh "rdf serialize --output-format jsonld rdfa-1.1.html -o rdfa-1.1.jsonld"
+end
+
+desc "Build context from rdfa-1.1.jsonld"
+file "context.jsonld" => "rdfa-1.1.jsonld" do
+  sh "scripts/gen_context.rb rdfa-1.1.jsonld > context.jsonld" 
+end

--- a/scripts/gen_context.rb
+++ b/scripts/gen_context.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# Creates a JSON-LD context from the JSON-LD representation of the prefixes
+require 'json'
+
+JSON_STATE = JSON::State.new(
+  indent:       "  ",
+  space:        " ",
+  space_before: "",
+  object_nl:    "\n",
+  array_nl:     "\n"
+)
+
+context = {'@context' => {}}
+
+File.open(ARGV[0]) do |f|
+  input = JSON.load(f)
+
+  # Prefix mappings
+  input['@graph'].
+    filter {|o| o['@type'] == 'rdfa:PrefixMapping'}.
+    sort_by {|o| o['rdfa:prefix']}.
+    each do |obj|
+
+    context['@context'][obj['rdfa:prefix']] = obj['rdfa:uri']
+  end
+
+  # Term mappings
+  input['@graph'].
+    filter {|o| o['@type'] == 'rdfa:TermMapping'}.
+    sort_by {|o| o['rdfa:term']}.
+    each do |obj|
+
+    context['@context'][obj['rdfa:term']] = obj['rdfa:uri']
+  end
+end
+
+$stdout.puts(context.to_json(JSON_STATE))


### PR DESCRIPTION
to update rdfa variations for prefixes and terms and to update  context.jsonld.

This builds rdfa-1.1.ttl, rdfa-1.1.rdf, and rdfa-1.1.jsonld from rdfa-1.1.jsonld from rdfa-1.1.html. It also builds context.jsonld from rdfa-1.1.jsonld.
